### PR TITLE
fs/fuse/passthrough.c: fix redefinition of 'kiocb_clone'

### DIFF
--- a/fs/fuse/passthrough.c
+++ b/fs/fuse/passthrough.c
@@ -47,18 +47,6 @@ static void fuse_file_accessed(struct file *dst_file, struct file *src_file)
 	touch_atime(&dst_file->f_path);
 }
 
-static inline void kiocb_clone(struct kiocb *kiocb, struct kiocb *kiocb_src,
-			       struct file *filp)
-{
-	*kiocb = (struct kiocb){
-		.ki_filp = filp,
-		.ki_flags = kiocb_src->ki_flags,
-		.ki_hint = kiocb_src->ki_hint,
-		.ki_ioprio = kiocb_src->ki_ioprio,
-		.ki_pos = kiocb_src->ki_pos,
-	};
-}
-
 static void fuse_copyattr(struct file *dst_file, struct file *src_file)
 {
 	struct inode *dst = file_inode(dst_file);


### PR DESCRIPTION
../fs/fuse/passthrough.c:50:20: error: redefinition of 'kiocb_clone' static inline void kiocb_clone(struct kiocb *kiocb, struct kiocb *kiocb_src,

thanks to @bukan_ratabb