### PR TITLE
bpf: Implement fake uname for bpfloader, netbpfload, netd, uprobestats

### DIFF
--- a/init/Kconfig
+++ b/init/Kconfig
@@ -57,6 +57,37 @@ config CC_CAN_LINK_STATIC
 	default $(success,$(srctree)/scripts/cc-can-link.sh $(CC) -static $(m64-flag)) if 64BIT
 	default $(success,$(srctree)/scripts/cc-can-link.sh $(CC) -static $(m32-flag))
 
+choice
+    prompt "Fake uname kernel version"
+    default FAKE_UNAME_NONE
+    help
+      Kernel side spoof for BPF.
+
+config FAKE_UNAME_NONE
+    bool "None"
+    help
+      Don't spoof uname version.
+
+config FAKE_UNAME_5_4
+    bool "5.4"
+
+config FAKE_UNAME_5_10
+    bool "5.10"
+
+config FAKE_UNAME_5_15
+    bool "5.15"
+
+config FAKE_UNAME_6_1
+	bool "6.1"
+
+config FAKE_UNAME_6_6
+	bool "6.6"
+
+config FAKE_UNAME_6_12
+	bool "6.12"
+
+endchoice
+
 config CC_HAS_ASM_GOTO
 	def_bool $(success,$(srctree)/scripts/gcc-goto.sh $(CC))
 

--- a/kernel/sys.c
+++ b/kernel/sys.c
@@ -1257,12 +1257,37 @@ static int override_release(char __user *release, size_t len)
 	return ret;
 }
 
+#ifndef CONFIG_FAKE_UNAME_NONE
+#if defined(CONFIG_FAKE_UNAME_5_4)
+#define FAKE_UNAME "5.4.296"
+#elif defined(CONFIG_FAKE_UNAME_5_10)
+#define FAKE_UNAME "5.10.241"
+#elif defined(CONFIG_FAKE_UNAME_5_15)
+#define FAKE_UNAME "5.15.190"
+#elif defined(CONFIG_FAKE_UNAME_6_1)
+#define FAKE_UNAME "6.1.149"
+#elif defined(CONFIG_FAKE_UNAME_6_6)
+#define FAKE_UNAME "6.6.103"
+#elif defined(CONFIG_FAKE_UNAME_6_12)
+#define FAKE_UNAME "6.12.44"
+#endif
+#endif
 SYSCALL_DEFINE1(newuname, struct new_utsname __user *, name)
 {
 	struct new_utsname tmp;
 
 	down_read(&uts_sem);
 	memcpy(&tmp, utsname(), sizeof(tmp));
+#ifndef CONFIG_FAKE_UNAME_NONE
+	if (!strncmp(current->comm, "bpfloader", 9) ||
+	    !strncmp(current->comm, "netbpfload", 10) ||
+	    !strncmp(current->comm, "netd", 4) ||
+	    !strncmp(current->comm, "uprobestats", 11)) {
+		strcpy(tmp.release, FAKE_UNAME);
+		pr_debug("fake uname: %s/%d release=%s\n",
+			 current->comm, current->pid, tmp.release);
+	}
+#endif
 	up_read(&uts_sem);
 	if (copy_to_user(name, &tmp, sizeof(tmp)))
 		return -EFAULT;


### PR DESCRIPTION
Add fake uname kernel version spoofing. This changes allows this kernel to boot on Android 16 HyperOS 3.

Changes
- init/Kconfig: Add fake uname version selection menu Options: 5.4, 5.10, 5.15, 6.1, 6.6, 6.12, or None (default)

- kernel/sys.c: Implement uname spoofing in newuname syscall Intercepts uname calls from:
  * bpfloader - Android BPF program loader
  * netbpfload - Network BPF loader
  * netd - Network daemon
  * uprobestats - Uprobe statistics service

  When these processes (running as root) call uname, they receive
  the configured fake kernel version instead of the real version.

This is nothing new and is taken from work by other kernel devs like @angelomds42 working on spes kernels.